### PR TITLE
Filter with just genes

### DIFF
--- a/api/axies/all.ts
+++ b/api/axies/all.ts
@@ -6,7 +6,7 @@ import getAllPossibleAxies from '../../services/getAllPossibleAxies'
 import { ResultFormat } from '../../types/axies.types'
 import { Pagination } from '../../types/pagination.types'
 import filterDuplicates from '../../utils/filterDuplicates'
-import { formatAxiesMinimal } from '../../utils/formatAxies'
+import { formatAxies } from '../../utils/formatAxies'
 
 export const router: Router = Router()
 
@@ -23,9 +23,7 @@ app.post(`${axiesPath}/all`, async (req: Request, res: Response) => {
   const { format = 'minimal' } = req.query as {format:ResultFormat}
   const response = await getAllPossibleAxies(body, body)
   const filteredAxies = filterDuplicates(response)
-  const formattedAxies = format === 'minimal'
-    ? formatAxiesMinimal(filteredAxies)
-    : filteredAxies
+  const formattedAxies = formatAxies(format, filteredAxies)
   const pagination: Pagination = {
     total: filteredAxies.length,
     pages: 1,

--- a/api/axies/index.ts
+++ b/api/axies/index.ts
@@ -1,13 +1,13 @@
 import { PartGene } from 'agp-npm/dist/models/part'
 import { Request, Response, Router } from 'express'
+import app from '../../constants/app'
 import { BASE_URL } from '../../constants/router.constants'
 import getAllPossibleAxies from '../../services/getAllPossibleAxies'
 import getAxies from '../../services/getAxies'
-import { Pagination } from '../../types/pagination.types'
-import app from '../../constants/app'
-import filterDuplicates from '../../utils/filterDuplicates'
 import { ResultFormat } from '../../types/axies.types'
-import { formatAxiesMinimal } from '../../utils/formatAxies'
+import { Pagination } from '../../types/pagination.types'
+import filterDuplicates from '../../utils/filterDuplicates'
+import { formatAxies } from '../../utils/formatAxies'
 
 // Export module for registering router in express app
 export const router: Router = Router()
@@ -28,9 +28,7 @@ app.post(`${axiesPath}`, async (req, res) => {
   }
   const { format = 'minimal' } = req.query as {format:ResultFormat}
   const axies = await getAxies(body, body)
-  const formattedAxies = format === 'minimal'
-    ? formatAxiesMinimal(axies)
-    : axies
+  const formattedAxies = formatAxies(format, axies)
   const pagination: Pagination = {
     total: axies.length,
     pages: 1,
@@ -55,9 +53,7 @@ app.post(`${axiesPath}/all`, async (req:Request, res:Response) => {
   const { format = 'minimal' } = req.query as {format:ResultFormat}
   const response = await getAllPossibleAxies(body, body)
   const filteredAxies = filterDuplicates(response)
-  const formattedAxies = format === 'minimal'
-    ? formatAxiesMinimal(filteredAxies)
-    : filteredAxies
+  const formattedAxies = formatAxies(format, filteredAxies)
   const pagination: Pagination = {
     total: filteredAxies.length,
     pages: 1,

--- a/services/getAxies.ts
+++ b/services/getAxies.ts
@@ -32,7 +32,8 @@ export const getAxies: GetAxiesRequest = async (include, _parts, omit): Promise<
     .ax0
     .results
     .map((plainAxie) => {
-      const genes = new AxieGene(plainAxie.genes)
+      const _genes = plainAxie.genes
+      const genes = new AxieGene(_genes)
       const breakdownPurity = calculateBreakdownPurity(
         genes,
         { Back, Horn, Mouth, Tail }
@@ -42,6 +43,7 @@ export const getAxies: GetAxiesRequest = async (include, _parts, omit): Promise<
         id: plainAxie.id,
         price: plainAxie.auction.currentPrice,
         genes,
+        _genes,
         purity,
         breakdownPurity: breakdownPurity as BreakdownPurity
       }

--- a/types/axies.types.ts
+++ b/types/axies.types.ts
@@ -82,6 +82,7 @@ export interface BreakdownPurity {
 export interface Axie {
   id: string;
   genes: AxieGene;
+  _genes:string;
   price: string;
   purity: number;
   breakdownPurity: BreakdownPurity;
@@ -121,4 +122,4 @@ export type PlainAxieResult= {
   }
 }
 
-export type ResultFormat = 'minimal' |'full'|'justGenes';
+export type ResultFormat = 'minimal' |'full'|'plainGenes';

--- a/types/axies.types.ts
+++ b/types/axies.types.ts
@@ -121,4 +121,4 @@ export type PlainAxieResult= {
   }
 }
 
-export type ResultFormat = 'minimal' |'full';
+export type ResultFormat = 'minimal' |'full'|'justGenes';

--- a/utils/formatAxies.ts
+++ b/utils/formatAxies.ts
@@ -1,7 +1,7 @@
 import { AxieGene } from 'agp-npm/dist/axie-gene'
 import { Cls } from 'agp-npm/dist/models/cls'
 import { Part, PartGene } from 'agp-npm/dist/models/part'
-import { Axie } from '../types/axies.types'
+import { Axie, ResultFormat } from '../types/axies.types'
 
 function mapPartGenesMinimal (part:Part) {
   return Object.entries(part)
@@ -37,4 +37,31 @@ export function formatAxiesMinimal (axies:Axie[]) {
     purity: axie.purity,
     breakdownPurity: axie.breakdownPurity
   }))
+}
+
+export function formatJustGenes (gene:AxieGene) {
+  return gene.geneBinGroup
+}
+
+export function formatAxiesJustGenes (axies:Axie[]) {
+  return axies.map(axie => ({
+    id: axie.id,
+    genes: formatJustGenes(axie.genes),
+    price: axie.price,
+    purity: axie.purity,
+    breakdownPurity: axie.breakdownPurity
+  }))
+}
+
+export function formatAxies (format:ResultFormat, axies:Axie[]) {
+  switch (format) {
+    case 'full':
+      return axies
+    case 'justGenes':
+      return formatAxiesJustGenes(axies)
+    case 'minimal':
+      return formatAxiesMinimal(axies)
+    default:
+      return formatAxiesMinimal(axies)
+  }
 }

--- a/utils/formatAxies.ts
+++ b/utils/formatAxies.ts
@@ -33,20 +33,18 @@ export function formatAxiesMinimal (axies:Axie[]) {
   return axies.map(axie => ({
     id: axie.id,
     genes: formatGeneMinimal(axie.genes),
+    _genes: axie._genes,
     price: axie.price,
     purity: axie.purity,
     breakdownPurity: axie.breakdownPurity
   }))
 }
 
-export function formatJustGenes (gene:AxieGene) {
-  return gene.geneBinGroup
-}
-
-export function formatAxiesJustGenes (axies:Axie[]) {
+export function formatAxiesplainGenes (axies:Axie[]) {
   return axies.map(axie => ({
     id: axie.id,
-    genes: formatJustGenes(axie.genes),
+    genes: axie._genes,
+    _genes: axie._genes,
     price: axie.price,
     purity: axie.purity,
     breakdownPurity: axie.breakdownPurity
@@ -57,8 +55,8 @@ export function formatAxies (format:ResultFormat, axies:Axie[]) {
   switch (format) {
     case 'full':
       return axies
-    case 'justGenes':
-      return formatAxiesJustGenes(axies)
+    case 'plainGenes':
+      return formatAxiesplainGenes(axies)
     case 'minimal':
       return formatAxiesMinimal(axies)
     default:


### PR DESCRIPTION
The param 'format=justGenes', returns just the genes (less space)

```bash
curl --location --request POST 'http://localhost:3000/api/axies/all?format=justGenes' \
--header 'Content-Type: application/json' \
--data-raw '{
  "Tail":{
    "partId":"koi",
    "name":"koi",
    "cls":"aquatic"
  },
  "Mouth":{
    "cls":"mouth",
    "partId":"risky-fish",
    "name":"risky-fish"
  },
  "Back":{
    "partId":"goldfish",
    "name":"goldfish",
    "cls":"aquatic"
  },
  "Horn":{
    "partId":"cuckoo",
    "name":"cuckoo",
    "cls":"bird"
  },
  "species":[
    "Aquatic"
  ],
  "Ears":[
    "Aquatic",
    "Bird"
  ],
  "Eyes":[
    "Aquatic",
    "Bird"
  ]
}'
```

![image](https://user-images.githubusercontent.com/6518316/139564247-5c9e992b-d8b1-4f04-a4b2-a8f9314d3a31.png)
